### PR TITLE
Enable SO_REUSEADDR by passing a broadcast address to ListenUDP

### DIFF
--- a/examples/intface/intface.go
+++ b/examples/intface/intface.go
@@ -105,7 +105,8 @@ type agent_t struct {
 func new_agent() (agent *agent_t) {
 
 	// push output from udp into zmq socket
-	conn, e := net.ListenUDP("udp", &net.UDPAddr{Port: PING_PORT_NUMBER})
+	bcast := &net.UDPAddr{Port: PING_PORT_NUMBER, IP: net.IPv4bcast}
+	conn, e := net.ListenUDP("udp", bcast)
 	if e != nil {
 		panic(e)
 	}

--- a/examples/udpping2.go
+++ b/examples/udpping2.go
@@ -25,14 +25,13 @@ func main() {
 	log.SetFlags(log.Lshortfile)
 
 	//  Create UDP socket
-
-	conn, err := net.ListenUDP("udp", &net.UDPAddr{Port: PING_PORT_NUMBER})
+	bcast := &net.UDPAddr{Port: PING_PORT_NUMBER, IP: net.IPv4bcast}
+	conn, err := net.ListenUDP("udp", bcast)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
 	buffer := make([]byte, PING_MSG_SIZE)
-	bcast := &net.UDPAddr{Port: PING_PORT_NUMBER, IP: net.IPv4bcast}
 
 	//  We send a beacon once a second, and we collect and report
 	//  beacons that come in from other nodes:


### PR DESCRIPTION
Now we can reuse the address and test the intface and udpping2 in one
device
