### PR TITLE
Update Build.sh

### DIFF
--- a/examples/Build.sh
+++ b/examples/Build.sh
@@ -53,7 +53,7 @@ do
     fi
 done
 
-libs=`pkg-config --libs-only-L libzmq`
+libs=$(pkg-config --libs-only-L libzmq |tr -d "\n" | sed -e "s/[ \t]*$//")
 if [ "$libs" = "" ]
 then
     for i in $src


### PR DESCRIPTION
This is a fix for pkg-config on Fedora 19 which adds a space and newline at the end of the `pkg-config --libs-only-L libzmq` command.

[tim@titanium ~]$ cat /etc/redhat-release
Fedora release 19 (Schrödinger’s Cat)
[tim@titanium ~]$ pkg-config --libs-only-L libzmq|hexdump
0000000 0a20  
0000002
[tim@titanium ~]$ printf " \n"| hexdump
0000000 0a20  
0000002
