### PR TITLE
Socket: Make the raw 0MQ socket accessible

### DIFF
--- a/zmq3.go
+++ b/zmq3.go
@@ -332,6 +332,13 @@ func (soc Socket) String() string {
 }
 
 /*
+Socket as a raw 0MQ socket.
+*/
+func (soc *Socket) Raw() unsafe.Pointer {
+	return soc.soc
+}
+
+/*
 Create 0MQ socket.
 
 WARNING:


### PR DESCRIPTION
Add Socket.Raw() method that returns the underlying 0MQ socket as
unsafe.Pointer. This is useful for implementing custom polling and other stuff,
which I would really like and need to do. It could make my code much more
elegant and less complicated...

Please merge this!
